### PR TITLE
navigation-test-prototype

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "packageManager": "pnpm@9.15.1",
   "dependencies": {
     "@expo/vector-icons": "^14.0.2",
+    "@faker-js/faker": "^9.5.0",
     "@gluestack-ui/button": "^1.0.8",
     "@gluestack-ui/checkbox": "^0.1.33",
     "@gluestack-ui/icon": "^0.1.25",
@@ -42,6 +43,7 @@
     "expo-symbols": "~0.2.0",
     "expo-system-ui": "~4.0.4",
     "expo-web-browser": "~14.0.1",
+    "fp-ts": "^2.16.9",
     "lucide-react-native": "^0.474.0",
     "nativewind": "^4.1.23",
     "react": "18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@expo/vector-icons':
         specifier: ^14.0.2
         version: 14.0.4
+      '@faker-js/faker':
+        specifier: ^9.5.0
+        version: 9.5.0
       '@gluestack-ui/button':
         specifier: ^1.0.8
         version: 1.0.8(react-dom@18.3.1(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1))(react@18.3.1)
@@ -80,6 +83,9 @@ importers:
       expo-web-browser:
         specifier: ~14.0.1
         version: 14.0.1(expo@52.0.11(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.0(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1)))(react-native-webview@13.12.2(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1))
+      fp-ts:
+        specifier: ^2.16.9
+        version: 2.16.9
       lucide-react-native:
         specifier: ^0.474.0
         version: 0.474.0(react-native-svg@15.8.0(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.12)(react@18.3.1))(react@18.3.1)
@@ -1033,6 +1039,10 @@ packages:
   '@expo/xcpretty@4.3.1':
     resolution: {integrity: sha512-sqXgo1SCv+j4VtYEwl/bukuOIBrVgx6euIoCat3Iyx5oeoXwEA2USCoeL0IPubflMxncA2INkqJ/Wr3NGrSgzw==}
     hasBin: true
+
+  '@faker-js/faker@9.5.0':
+    resolution: {integrity: sha512-3qbjLv+fzuuCg3umxc9/7YjrEXNaKwHgmig949nfyaTx8eL4FAsvFbu+1JcFUj1YAXofhaDn6JdEUBTYuk0Ssw==}
+    engines: {node: '>=18.0.0', npm: '>=9.0.0'}
 
   '@formatjs/ecma402-abstract@2.3.2':
     resolution: {integrity: sha512-6sE5nyvDloULiyOMbOTJEEgWL32w+VHkZQs8S02Lnn8Y/O5aQhjOEXwWzvR7SsBE/exxlSpY2EsWZgqHbtLatg==}
@@ -3162,6 +3172,9 @@ packages:
   form-data@4.0.1:
     resolution: {integrity: sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==}
     engines: {node: '>= 6'}
+
+  fp-ts@2.16.9:
+    resolution: {integrity: sha512-+I2+FnVB+tVaxcYyQkHUq7ZdKScaBlX53A41mxQtpIccsfyv8PzdzP7fzp2AY832T4aoK6UZ5WRX/ebGd8uZuQ==}
 
   freeport-async@2.0.0:
     resolution: {integrity: sha512-K7od3Uw45AJg00XUmy15+Hae2hOcgKcmN3/EF6Y7i01O0gaqiRx8sUSpsb9+BRNL8RPBrhzPsVfy8q9ADlJuWQ==}
@@ -7216,6 +7229,8 @@ snapshots:
       find-up: 5.0.0
       js-yaml: 4.1.0
 
+  '@faker-js/faker@9.5.0': {}
+
   '@formatjs/ecma402-abstract@2.3.2':
     dependencies:
       '@formatjs/fast-memoize': 2.2.6
@@ -10028,6 +10043,8 @@ snapshots:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
+
+  fp-ts@2.16.9: {}
 
   freeport-async@2.0.0: {}
 

--- a/src/app/(tabs)/index.tsx
+++ b/src/app/(tabs)/index.tsx
@@ -1,27 +1,2 @@
-import { CheckIcon } from "lucide-react-native";
-import { Text, View } from "react-native";
-
-import {
-  Checkbox,
-  CheckboxIndicator,
-  CheckboxLabel,
-  CheckboxIcon,
-} from "~/shared/ui";
-import { Button, ButtonText } from "~/shared/ui/Button";
-
-export default function Index() {
-  return (
-    <View className="p-4">
-      <Text className="text-lg font-bold">View</Text>
-      <Button>
-        <ButtonText>hi</ButtonText>
-      </Button>
-      <Checkbox size="lg" isInvalid={false} isDisabled={false} value="none">
-        <CheckboxIndicator>
-          <CheckboxIcon as={CheckIcon} />
-        </CheckboxIndicator>
-        <CheckboxLabel>Label</CheckboxLabel>
-      </Checkbox>
-    </View>
-  );
-}
+import { WordbookList } from "~/pages/WordbookList";
+export default WordbookList;

--- a/src/app/(tabs)/wordbook.tsx
+++ b/src/app/(tabs)/wordbook.tsx
@@ -1,0 +1,2 @@
+import { Wordbook } from "~/pages/Wordbook";
+export default Wordbook;

--- a/src/app/word/[id].tsx
+++ b/src/app/word/[id].tsx
@@ -1,0 +1,24 @@
+import { Stack, useLocalSearchParams } from "expo-router";
+import { useMemo } from "react";
+import { Text, View } from "react-native";
+
+import { words } from "~/pages/WordbookList/data";
+
+export default function Word() {
+  const { id } = useLocalSearchParams();
+  const word = useMemo(
+    () => words.filter(({ id: wordId }) => wordId === `${id}`)[0],
+    [id],
+  );
+
+  return (
+    <View className="flex-1 items-center justify-center p-2">
+      <Stack.Screen
+        options={{
+          title: word.words.join(" / "),
+        }}
+      />
+      <Text>{word.words.join(" / ")}</Text>
+    </View>
+  );
+}

--- a/src/app/wordbook/[id].tsx
+++ b/src/app/wordbook/[id].tsx
@@ -1,0 +1,43 @@
+import { Stack, useLocalSearchParams } from "expo-router";
+import { pipe } from "fp-ts/lib/function";
+import { useMemo } from "react";
+import { FlatList, View } from "react-native";
+
+import { wordBooks, words } from "~/pages/WordbookList/data";
+import { Button, ButtonText } from "~/shared/ui";
+
+export default function Wordbook() {
+  const { id } = useLocalSearchParams();
+  const wordbook = useMemo(
+    () => wordBooks.filter(({ id: wordbookId }) => wordbookId === `${id}`)[0],
+    [id],
+  );
+
+  return (
+    <View className="flex-1 items-center justify-center p-2">
+      <Stack.Screen
+        options={{
+          title: wordbook.name,
+        }}
+      />
+      <FlatList
+        className="w-full"
+        contentContainerClassName="gap-2 pr-4"
+        data={wordbook.wordIds}
+        renderItem={({ item: id }) => (
+          <Button variant="outline" className="ml-4">
+            {pipe(
+              words.filter(({ id: wordId }) => wordId === id)[0],
+              ({ words, meanings }) => (
+                <>
+                  <ButtonText>{words.join(" / ")}</ButtonText>
+                  <ButtonText>{meanings.join(" / ")}</ButtonText>
+                </>
+              ),
+            )}
+          </Button>
+        )}
+      />
+    </View>
+  );
+}

--- a/src/app/wordbook/[id].tsx
+++ b/src/app/wordbook/[id].tsx
@@ -1,4 +1,4 @@
-import { Stack, useLocalSearchParams } from "expo-router";
+import { Link, Stack, useLocalSearchParams } from "expo-router";
 import { pipe } from "fp-ts/lib/function";
 import { useMemo } from "react";
 import { FlatList, View } from "react-native";
@@ -25,17 +25,19 @@ export default function Wordbook() {
         contentContainerClassName="gap-2 pr-4"
         data={wordbook.wordIds}
         renderItem={({ item: id }) => (
-          <Button variant="outline" className="ml-4">
-            {pipe(
-              words.filter(({ id: wordId }) => wordId === id)[0],
-              ({ words, meanings }) => (
-                <>
-                  <ButtonText>{words.join(" / ")}</ButtonText>
-                  <ButtonText>{meanings.join(" / ")}</ButtonText>
-                </>
-              ),
-            )}
-          </Button>
+          <Link href={`/word/${id}`} asChild>
+            <Button variant="outline" className="ml-4">
+              {pipe(
+                words.filter(({ id: wordId }) => wordId === id)[0],
+                ({ words, meanings }) => (
+                  <>
+                    <ButtonText>{words.join(" / ")}</ButtonText>
+                    <ButtonText>{meanings.join(" / ")}</ButtonText>
+                  </>
+                ),
+              )}
+            </Button>
+          </Link>
         )}
       />
     </View>

--- a/src/entities/word/types.ts
+++ b/src/entities/word/types.ts
@@ -1,0 +1,6 @@
+export interface Word {
+  id: string;
+  words: string[];
+  meanings: string[];
+  dictions: string[];
+}

--- a/src/entities/wordbook/types.ts
+++ b/src/entities/wordbook/types.ts
@@ -1,0 +1,6 @@
+export interface Wordbook {
+  id: string;
+  name: string;
+  language: string;
+  wordIds: string[];
+}

--- a/src/pages/Wordbook/Wordbook.tsx
+++ b/src/pages/Wordbook/Wordbook.tsx
@@ -1,0 +1,9 @@
+import { Text, View } from "react-native";
+
+export const Wordbook = () => {
+  return (
+    <View>
+      <Text>Wordbook</Text>
+    </View>
+  );
+};

--- a/src/pages/Wordbook/index.ts
+++ b/src/pages/Wordbook/index.ts
@@ -1,0 +1,1 @@
+export { Wordbook } from "./Wordbook";

--- a/src/pages/WordbookList/WordbookList.tsx
+++ b/src/pages/WordbookList/WordbookList.tsx
@@ -1,0 +1,24 @@
+import { Link } from "expo-router";
+import { FlatList, View } from "react-native";
+
+import { Button, ButtonText } from "~/shared/ui";
+
+import { wordBooks } from "./data";
+
+export const WordbookList = () => {
+  return (
+    <View className="p-4">
+      <FlatList
+        data={wordBooks}
+        renderItem={({ item }) => (
+          <Link href={`/wordbook/${item.id}`} asChild>
+            <Button className="my-2 h-fit p-4" size="xl" variant="outline">
+              <ButtonText>{item.name}</ButtonText>
+            </Button>
+          </Link>
+        )}
+        keyExtractor={(item) => item.id}
+      />
+    </View>
+  );
+};

--- a/src/pages/WordbookList/data.ts
+++ b/src/pages/WordbookList/data.ts
@@ -1,0 +1,27 @@
+import { faker, fakerKO } from "@faker-js/faker";
+
+import { type Word } from "~/entities/word/types";
+import { type Wordbook } from "~/entities/wordbook/types";
+
+export const WORD_COUNT = 100;
+export const WORDBOOK_COUNT = 20;
+
+export const words = Array.from({ length: WORD_COUNT }).map(
+  (_, i): Word => ({
+    id: `word-${i}`,
+    words: [faker.word.sample()],
+    meanings: [fakerKO.word.sample()],
+    dictions: [faker.word.sample()],
+  }),
+);
+
+export const wordBooks = Array.from({ length: WORDBOOK_COUNT }).map(
+  (_, i): Wordbook => ({
+    id: `wordbook-${i}`,
+    name: `Wordbook ${i + 1}`,
+    language: "en",
+    wordIds: Array.from({ length: Math.floor(50 + Math.random() * 50) }).map(
+      (_, j) => `word-${j}`,
+    ),
+  }),
+);

--- a/src/pages/WordbookList/index.ts
+++ b/src/pages/WordbookList/index.ts
@@ -1,0 +1,1 @@
+export { WordbookList } from "./WordbookList";


### PR DESCRIPTION
This pull request introduces a navigation test prototype, including two main components:

1. **WordbookList Component and Dummy Data Setup**: A new `WordbookList` component has been added to the project. This component is designed to display a list of wordbooks, and for the purpose of this prototype, it includes a setup with dummy data to simulate its functionality. This will allow us to test out the navigation features and user interactions with the wordbook list.

2. **Word Page Addition**: Alongside the `WordbookList`, a basic `WordPage` has been implemented. This page will serve as the destination when selecting an item from the wordbook list, enabling further actions or display of detailed information about the chosen word.

These changes are part of a broader initiative to prototype the navigation system of our application, offering a foundation to experiment with different user flows and layouts. Feedback is welcome on the structure and implementation approach as we iterate on this prototype.